### PR TITLE
Support environment variables when Clowder is disabled

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -136,31 +136,32 @@ func initConfig() {
 	} else {
 		viper.SetDefault("LogFormater", "text")
 
-		viper.SetDefault("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
-		viper.SetDefault("UPLOAD_TOPIC", "hccm.ros.events")
-		viper.SetDefault("RECOMMENDATION_TOPIC", "rosocp.kruize.recommendations")
-		viper.SetDefault("SOURCES_EVENT_TOPIC", "platform.sources.event-stream")
+		// Kafka Config - read from environment variables first, fallback to defaults
+		viper.SetDefault("KAFKA_BOOTSTRAP_SERVERS", getEnvWithDefault("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092"))
+		viper.SetDefault("UPLOAD_TOPIC", getEnvWithDefault("UPLOAD_TOPIC", "hccm.ros.events"))
+		viper.SetDefault("RECOMMENDATION_TOPIC", getEnvWithDefault("RECOMMENDATION_TOPIC", "rosocp.kruize.recommendations"))
+		viper.SetDefault("SOURCES_EVENT_TOPIC", getEnvWithDefault("SOURCES_EVENT_TOPIC", "platform.sources.event-stream"))
 
-		// default DB Config
-		viper.SetDefault("DBName", "postgres")
-		viper.SetDefault("DBUser", "postgres")
-		viper.SetDefault("DBPassword", "postgres")
-		viper.SetDefault("DBHost", "localhost")
-		viper.SetDefault("DBPort", "15432")
-		viper.SetDefault("DBssl", "disable")
+		// DB Config - read from environment variables first, fallback to defaults
+		viper.SetDefault("DBHost", getEnvWithDefault("DB_HOST", "localhost"))
+		viper.SetDefault("DBPort", getEnvWithDefault("DB_PORT", "15432"))
+		viper.SetDefault("DBName", getEnvWithDefault("DB_NAME", "postgres"))
+		viper.SetDefault("DBUser", getEnvWithDefault("DB_USER", "postgres"))
+		viper.SetDefault("DBPassword", getEnvWithDefault("DB_PASSWORD", "postgres"))
+		viper.SetDefault("DBssl", getEnvWithDefault("DB_SSL", "disable"))
 		viper.SetDefault("DBCACert", "")
 
-		// default RBAC Config
-		viper.SetDefault("RBACHost", "localhost")
-		viper.SetDefault("RBACPort", "9080")
+		// RBAC Config - read from environment variables first, fallback to defaults
+		viper.SetDefault("RBACHost", getEnvWithDefault("RBAC_HOST", "localhost"))
+		viper.SetDefault("RBACPort", getEnvWithDefault("RBAC_PORT", "9080"))
 		viper.SetDefault("RBACProtocol", "http")
 		viper.SetDefault("RBAC_ENABLE", false)
 
-		// prometheus config
-		viper.SetDefault("PROMETHEUS_PORT", "5005")
+		// Prometheus config - read from environment variables first, fallback to defaults
+		viper.SetDefault("PROMETHEUS_PORT", getEnvWithDefault("PROMETHEUS_PORT", "5005"))
 
-		// Sources-api-go
-		viper.SetDefault("SOURCES_API_BASE_URL", "http://127.0.0.1:8002")
+		// Sources-api-go config - read from environment variables first, fallback to defaults
+		viper.SetDefault("SOURCES_API_BASE_URL", getEnvWithDefault("SOURCES_API_BASE_URL", "http://127.0.0.1:8002"))
 
 	}
 
@@ -204,4 +205,13 @@ func GetConfig() *Config {
 		fmt.Println("Config initialized")
 	}
 	return cfg
+}
+
+// getEnvWithDefault returns the value of the environment variable with the given key,
+// or the default value if the environment variable is not set or is empty.
+func getEnvWithDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,107 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetEnvWithDefault(t *testing.T) {
+	tests := []struct {
+		name         string
+		envKey       string
+		envValue     string
+		defaultValue string
+		expected     string
+		setEnv       bool
+	}{
+		{
+			name:         "returns environment variable when set",
+			envKey:       "TEST_ENV_VAR",
+			envValue:     "test_value",
+			defaultValue: "default_value",
+			expected:     "test_value",
+			setEnv:       true,
+		},
+		{
+			name:         "returns default when environment variable not set",
+			envKey:       "UNSET_ENV_VAR",
+			envValue:     "",
+			defaultValue: "default_value",
+			expected:     "default_value",
+			setEnv:       false,
+		},
+		{
+			name:         "returns default when environment variable is empty string",
+			envKey:       "EMPTY_ENV_VAR",
+			envValue:     "",
+			defaultValue: "default_value",
+			expected:     "default_value",
+			setEnv:       true,
+		},
+		{
+			name:         "handles empty default value",
+			envKey:       "ANOTHER_UNSET_VAR",
+			envValue:     "",
+			defaultValue: "",
+			expected:     "",
+			setEnv:       false,
+		},
+		{
+			name:         "handles special characters in environment variable",
+			envKey:       "SPECIAL_CHARS_VAR",
+			envValue:     "value-with_special.chars:123",
+			defaultValue: "default",
+			expected:     "value-with_special.chars:123",
+			setEnv:       true,
+		},
+		{
+			name:         "handles spaces in environment variable",
+			envKey:       "SPACES_VAR",
+			envValue:     "value with spaces",
+			defaultValue: "default",
+			expected:     "value with spaces",
+			setEnv:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clean up environment variable before test
+			os.Unsetenv(tt.envKey)
+
+			// Set environment variable if required
+			if tt.setEnv {
+				err := os.Setenv(tt.envKey, tt.envValue)
+				if err != nil {
+					t.Fatalf("Failed to set environment variable: %v", err)
+				}
+				// Clean up after test
+				defer os.Unsetenv(tt.envKey)
+			}
+
+			// Test the function
+			result := getEnvWithDefault(tt.envKey, tt.defaultValue)
+
+			// Verify the result
+			if result != tt.expected {
+				t.Errorf("getEnvWithDefault(%q, %q) = %q, want %q",
+					tt.envKey, tt.defaultValue, result, tt.expected)
+			}
+		})
+	}
+}
+
+// Benchmark test to ensure the function is efficient
+func BenchmarkGetEnvWithDefault(b *testing.B) {
+	// Set up test environment variable
+	os.Setenv("BENCHMARK_VAR", "benchmark_value")
+	defer os.Unsetenv("BENCHMARK_VAR")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Test with existing env var
+		getEnvWithDefault("BENCHMARK_VAR", "default")
+		// Test with non-existing env var
+		getEnvWithDefault("NON_EXISTING_VAR", "default")
+	}
+}


### PR DESCRIPTION
- Modified internal/config/config.go to read configuration from environment variables when CLOWDER_ENABLED=false
- Added support for DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD, DB_SSL environment variables
- Added support for KAFKA_BOOTSTRAP_SERVERS, UPLOAD_TOPIC, RECOMMENDATION_TOPIC, SOURCES_EVENT_TOPIC
- Added support for RBAC_HOST, RBAC_PORT, PROMETHEUS_PORT, SOURCES_API_BASE_URL
- Maintains backward compatibility with existing defaults when environment variables are not set
- Enables containerized deployment without Clowder dependency

🤖 Generated with [Claude Code](https://claude.ai/code) and Cursor AI (and me).
