### PR TITLE
Add cluster role and service account definition for ROS OCP backend API deployment

### DIFF
--- a/deployment/docker-compose/docker-compose.override.yml
+++ b/deployment/docker-compose/docker-compose.override.yml
@@ -11,13 +11,13 @@ version: "3.8"
 services:
 
   db-ros:
-    image: postgres:16
+    image: quay.io/insights-onprem/postgres:16
 
   db-kruize:
-    image: postgres:16
+    image: quay.io/insights-onprem/postgres:16
 
   db-sources:
-    image: postgres:16
+    image: quay.io/insights-onprem/postgres:16
 
   nginx:
     image: nginx:stable-alpine-perl

--- a/deployment/kubernetes/helm/ros-ocp/templates/auth-cluster-roles-rosocp-api.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/auth-cluster-roles-rosocp-api.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tokenreview-creator
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ros-ocp-backend-tokenreview-binding
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ros-ocp.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: tokenreview-creator
+  apiGroup: rbac.authorization.k8s.io

--- a/deployment/kubernetes/helm/ros-ocp/templates/configmap-cdapp.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/configmap-cdapp.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-cdapp-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
 data:

--- a/deployment/kubernetes/helm/ros-ocp/templates/configmap-kruize-config.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/configmap-kruize-config.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-kruize-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
 data:

--- a/deployment/kubernetes/helm/ros-ocp/templates/configmap-samples.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/configmap-samples.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-samples
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
 data:

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-ingress.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-ingress
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: ingress

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-kruize.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-kruize.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-kruize
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: optimization

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-nginx.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-nginx.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-nginx
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: web

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-redis.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-redis.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-redis
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: cache

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-api.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-api.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-rosocp-api
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: api
@@ -20,6 +21,7 @@ spec:
         app.kubernetes.io/component: api
         app.kubernetes.io/name: rosocp-api
     spec:
+      serviceAccountName: {{ include "ros-ocp.serviceAccountName" . }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-housekeeper.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-housekeeper.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-rosocp-housekeeper
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: housekeeper

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-processor.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-processor.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-rosocp-processor
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: processor

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-recommendation-poller.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-recommendation-poller.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-rosocp-recommendation-poller
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: poller

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-sources-api.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-sources-api.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-sources-api
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: api

--- a/deployment/kubernetes/helm/ros-ocp/templates/job-kafka-topics.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/job-kafka-topics.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-kafka-topics
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: setup

--- a/deployment/kubernetes/helm/ros-ocp/templates/job-minio-buckets.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/job-minio-buckets.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-minio-buckets
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: setup

--- a/deployment/kubernetes/helm/ros-ocp/templates/ros-ocp-backend-serviceaccount.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/ros-ocp-backend-serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ros-ocp.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/deployment/kubernetes/helm/ros-ocp/templates/secret-db-credentials.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/secret-db-credentials.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-db-credentials
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
 type: Opaque

--- a/deployment/kubernetes/helm/ros-ocp/templates/secret-minio-credentials.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/secret-minio-credentials.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-minio-credentials
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
 type: Opaque

--- a/deployment/kubernetes/helm/ros-ocp/templates/secret-sources-credentials.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/secret-sources-credentials.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-sources-credentials
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
 type: Opaque

--- a/deployment/kubernetes/helm/ros-ocp/templates/service-db-kruize.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/service-db-kruize.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-db-kruize
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: database

--- a/deployment/kubernetes/helm/ros-ocp/templates/service-db-ros.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/service-db-ros.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-db-ros
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: database

--- a/deployment/kubernetes/helm/ros-ocp/templates/service-db-sources.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/service-db-sources.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-db-sources
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: database

--- a/deployment/kubernetes/helm/ros-ocp/templates/service-ingress.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/service-ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-ingress
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: ingress

--- a/deployment/kubernetes/helm/ros-ocp/templates/service-kafka.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/service-kafka.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-kafka
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka

--- a/deployment/kubernetes/helm/ros-ocp/templates/service-kruize.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/service-kruize.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-kruize
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: optimization

--- a/deployment/kubernetes/helm/ros-ocp/templates/service-minio.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/service-minio.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-minio
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: storage

--- a/deployment/kubernetes/helm/ros-ocp/templates/service-nginx.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/service-nginx.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-nginx
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: web

--- a/deployment/kubernetes/helm/ros-ocp/templates/service-redis.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/service-redis.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-redis
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: cache

--- a/deployment/kubernetes/helm/ros-ocp/templates/service-rosocp-api.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/service-rosocp-api.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-rosocp-api
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: api

--- a/deployment/kubernetes/helm/ros-ocp/templates/service-sources-api.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/service-sources-api.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-sources-api
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: api

--- a/deployment/kubernetes/helm/ros-ocp/templates/service-zookeeper.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/service-zookeeper.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-zookeeper
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper

--- a/deployment/kubernetes/helm/ros-ocp/templates/statefulset-db-kruize.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/statefulset-db-kruize.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-db-kruize
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: database

--- a/deployment/kubernetes/helm/ros-ocp/templates/statefulset-db-ros.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/statefulset-db-ros.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-db-ros
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: database

--- a/deployment/kubernetes/helm/ros-ocp/templates/statefulset-db-sources.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/statefulset-db-sources.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-db-sources
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: database

--- a/deployment/kubernetes/helm/ros-ocp/templates/statefulset-kafka.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/statefulset-kafka.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-kafka
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka

--- a/deployment/kubernetes/helm/ros-ocp/templates/statefulset-minio.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/statefulset-minio.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-minio
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: storage

--- a/deployment/kubernetes/helm/ros-ocp/templates/statefulset-zookeeper.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/statefulset-zookeeper.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "ros-ocp.fullname" . }}-zookeeper
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper

--- a/deployment/kubernetes/helm/ros-ocp/values.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/values.yaml
@@ -9,6 +9,9 @@ global:
   # Pull secrets for private registries
   imagePullSecrets: []
 
+serviceAccount:
+  name: ros-ocp-backend
+
 # Database configurations
 database:
   ros:
@@ -62,7 +65,6 @@ kafka:
       ZOOKEEPER_SERVER_ID: 1
     storage:
       size: 5Gi
-  
   broker:
     image:
       repository: confluentinc/cp-kafka
@@ -312,7 +314,7 @@ resources:
     limits:
       memory: "512Mi"
       cpu: "500m"
-  
+
   # Kafka minimum: ~512Mi memory, Zookeeper needs ~256Mi
   kafka:
     requests:
@@ -321,7 +323,7 @@ resources:
     limits:
       memory: "1Gi"
       cpu: "500m"
-  
+
   zookeeper:
     requests:
       memory: "256Mi"
@@ -329,7 +331,7 @@ resources:
     limits:
       memory: "512Mi"
       cpu: "250m"
-  
+
   # Regular application services
   application:
     requests:
@@ -338,7 +340,7 @@ resources:
     limits:
       memory: "512Mi"
       cpu: "300m"
-  
+
   # Kruize is memory-intensive (Java/ML workload)
   kruize:
     requests:


### PR DESCRIPTION
Add cluster role and service account template to the helm chart so that ROS-ocp-backend can create a TokenReviewer to authenticate the OAuth token coming from the header.
By default it uses the existing rhoss (X-RH-Identity header) to maintain backwards compatibility.