### PR TITLE
Add CronJob for partition cleanup to Helm chart

### DIFF
--- a/deployment/kubernetes/helm/ros-ocp/templates/cronjob-delete-rosocp-partitions.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/cronjob-delete-rosocp-partitions.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.rosocp.partitionCleaner.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: delete-rosocp-partitions
+  labels:
+    app: delete-rosocp-partitions
+    component: partition-cleaner
+spec:
+  schedule: {{ .Values.rosocp.partitionCleaner.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: delete-rosocp-partitions
+            component: partition-cleaner
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: {{ .Values.serviceAccount.name }}
+          containers:
+          - name: rosocp-partition-cleaner
+            image: {{ .Values.rosocp.partitionCleaner.image.repository }}:{{ .Values.rosocp.partitionCleaner.image.tag }}
+            imagePullPolicy: {{ .Values.global.pullPolicy }}
+            command: ["sh"]
+            args: ["-c", "./rosocp db migrate up && ./rosocp start housekeeper --partitions"]
+            env:
+            - name: CLOWDER_ENABLED
+              value: {{ .Values.rosocp.partitionCleaner.env.CLOWDER_ENABLED | quote }}
+            - name: SERVICE_NAME
+              value: {{ .Values.rosocp.partitionCleaner.env.SERVICE_NAME | quote }}
+            - name: LOG_LEVEL
+              value: {{ .Values.rosocp.partitionCleaner.env.LOG_LEVEL | quote }}
+            - name: DB_HOST
+              value: {{ .Values.rosocp.partitionCleaner.env.DB_HOST | quote }}
+            - name: DB_PORT
+              value: {{ .Values.rosocp.partitionCleaner.env.DB_PORT | quote }}
+            - name: DB_NAME
+              value: {{ .Values.rosocp.partitionCleaner.env.DB_NAME | quote }}
+            - name: DB_USER
+              value: {{ .Values.rosocp.partitionCleaner.env.DB_USER | quote }}
+            - name: DB_PASSWORD
+              value: {{ .Values.rosocp.partitionCleaner.env.DB_PASSWORD | quote }}
+            - name: DATABASE_URL
+              value: {{ .Values.rosocp.partitionCleaner.env.DATABASE_URL | quote }}
+            {{- if .Values.rosocp.partitionCleaner.resources }}
+            resources:
+              {{- toYaml .Values.rosocp.partitionCleaner.resources | nindent 14 }}
+            {{- end }}
+          {{- with .Values.global.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/deployment/kubernetes/helm/ros-ocp/values.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/values.yaml
@@ -287,6 +287,30 @@ rosocp:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       SOURCES_API_BASE_URL: http://sources-api-go:8000
 
+  partitionCleaner:
+    enabled: true
+    schedule: "0 0 */15 * *"  # Runs at 12:00 AM, every 15 days
+    image:
+      repository: quay.io/insights-onprem/ros-ocp-backend
+      tag: "latest"
+    env:
+      CLOWDER_ENABLED: false
+      SERVICE_NAME: rosocp-housekeeper-partition
+      LOG_LEVEL: INFO
+      DB_HOST: db-ros
+      DB_PORT: 5432
+      DB_NAME: postgres
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DATABASE_URL: postgresql://postgres:postgres@db-ros:5432/postgres?sslmode=disable
+    resources:
+      requests:
+        memory: "256Mi"
+        cpu: "100m"
+      limits:
+        memory: "512Mi"
+        cpu: "300m"
+
 # Service configuration
 service:
   type: ClusterIP


### PR DESCRIPTION
Convert the delete-rosocp-partitions job from clowdapp.yaml to a Kubernetes CronJob resource in the Helm chart. The CronJob runs every 15 days at midnight to clean up database partitions using the rosocp housekeeper --partitions command.

Changes:
- Add cronjob-delete-rosocp-partitions.yaml template
- Add partitionCleaner configuration section to values.yaml
- Include proper resource limits and environment variables
- Maintain same schedule as original clowdapp job (0 0 */15 * *)

🤖 Generated with [Claude Code](https://claude.ai/code)
