### PR TITLE
Add missing kruize jobs

### DIFF
--- a/deployment/kubernetes/helm/ros-ocp/templates/_helpers.tpl
+++ b/deployment/kubernetes/helm/ros-ocp/templates/_helpers.tpl
@@ -78,3 +78,14 @@ Get the database URL - returns complete postgresql connection string
 {{- define "ros-ocp.databaseUrl" -}}
 {{- printf "postgresql://postgres:$(DB_PASSWORD)@%s:%s/%s?sslmode=disable" (include "ros-ocp.databaseHost" .) (.Values.rosocp.database.port | toString) .Values.rosocp.database.name }}
 {{- end }}
+
+{{/*
+Get the kruize database host - returns internal service name if "internal", otherwise returns the configured host
+*/}}
+{{- define "ros-ocp.kruizeDatabaseHost" -}}
+{{- if eq .Values.database.kruize.host "internal" }}
+{{- printf "%s-db-kruize" (include "ros-ocp.fullname" .) }}
+{{- else }}
+{{- .Values.database.kruize.host }}
+{{- end }}
+{{- end }}

--- a/deployment/kubernetes/helm/ros-ocp/templates/configmap-kruize-config.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/configmap-kruize-config.yaml
@@ -9,14 +9,14 @@ data:
   cdappconfig.json: |
     {
       "database": {
-        "adminPassword": "postgres",
-        "adminUsername": "postgres",
-        "hostname": "{{ include "ros-ocp.fullname" . }}-db-kruize",
-        "name": "postgres",
-        "password": "postgres",
+        "adminPassword": "{{ .Values.database.kruize.adminPassword }}",
+        "adminUsername": "{{ .Values.database.kruize.adminUsername }}",
+        "hostname": "{{ include "ros-ocp.kruizeDatabaseHost" . }}",
+        "name": "{{ .Values.database.kruize.name }}",
+        "password": "{{ .Values.database.kruize.password }}",
         "port": {{ .Values.database.kruize.port }},
-        "username": "postgres",
-        "sslMode": "disable"
+        "username": "{{ .Values.database.kruize.username }}",
+        "sslMode": "{{ .Values.database.kruize.sslMode }}"
       },
       "kafka": {
         "brokers": [

--- a/deployment/kubernetes/helm/ros-ocp/templates/cronjob-kruize-partitions.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/cronjob-kruize-partitions.yaml
@@ -1,0 +1,96 @@
+{{- if .Values.kruize.partitions.deleteEnabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "ros-ocp.fullname" . }}-kruize-delete-partitions
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ros-ocp.labels" . | nindent 4 }}
+    app.kubernetes.io/component: maintenance
+    app.kubernetes.io/name: kruize-partitions
+spec:
+  schedule: {{ .Values.kruize.partitions.deleteSchedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.kruize.partitions.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.kruize.partitions.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "ros-ocp.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: maintenance
+            app.kubernetes.io/name: kruize-partitions
+        spec:
+          restartPolicy: OnFailure
+          {{- with .Values.global.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: delete-kruize-partitions
+              image: "{{ .Values.kruize.image.repository }}:{{ .Values.kruize.image.tag }}"
+              imagePullPolicy: {{ .Values.global.pullPolicy }}
+              command: ["sh"]
+              args: ["-c", "export DB_CONFIG_FILE={{ .Values.kruize.env.DB_CONFIG_FILE }} && /home/autotune/app/target/bin/RetentionPartition"]
+              env:
+                - name: START_AUTOTUNE
+                  value: "false"
+                - name: LOGGING_LEVEL
+                  value: {{ .Values.kruize.partitions.env.LOGGING_LEVEL | quote }}
+                - name: ROOT_LOGGING_LEVEL
+                  value: {{ .Values.kruize.env.ROOT_LOGGING_LEVEL | quote }}
+                - name: DB_CONFIG_FILE
+                  value: {{ .Values.kruize.env.DB_CONFIG_FILE | quote }}
+                - name: dbdriver
+                  value: {{ .Values.kruize.env.dbdriver | quote }}
+                - name: database_name
+                  value: {{ .Values.database.kruize.name | quote }}
+                - name: clustertype
+                  value: {{ .Values.kruize.env.clustertype | quote }}
+                - name: k8stype
+                  value: {{ .Values.kruize.env.k8stype | quote }}
+                - name: authtype
+                  value: {{ .Values.kruize.env.authtype | quote }}
+                - name: monitoringagent
+                  value: {{ .Values.kruize.env.monitoringagent | quote }}
+                - name: monitoringservice
+                  value: {{ .Values.kruize.env.monitoringservice | quote }}
+                - name: monitoringendpoint
+                  value: {{ .Values.kruize.env.monitoringendpoint | quote }}
+                - name: savetodb
+                  value: {{ .Values.kruize.env.savetodb | quote }}
+                - name: hibernate_dialect
+                  value: {{ .Values.kruize.env.hibernate_dialect | quote }}
+                - name: hibernate_driver
+                  value: {{ .Values.kruize.env.hibernate_driver | quote }}
+                - name: hibernate_c3p0minsize
+                  value: {{ .Values.kruize.env.hibernate_c3p0minsize | quote }}
+                - name: hibernate_c3p0maxsize
+                  value: {{ .Values.kruize.env.hibernate_c3p0maxsize | quote }}
+                - name: hibernate_c3p0timeout
+                  value: {{ .Values.kruize.env.hibernate_c3p0timeout | quote }}
+                - name: hibernate_c3p0maxstatements
+                  value: {{ .Values.kruize.env.hibernate_c3p0maxstatements | quote }}
+                - name: hibernate_hbm2ddlauto
+                  value: {{ .Values.kruize.env.hibernate_hbm2ddlauto | quote }}
+                - name: hibernate_showsql
+                  value: {{ .Values.kruize.env.hibernate_showsql | quote }}
+                - name: hibernate_timezone
+                  value: {{ .Values.kruize.env.hibernate_timezone | quote }}
+                - name: deletepartitionsthreshold
+                  value: {{ .Values.kruize.partitions.env.deletepartitionsthreshold | quote }}
+                - name: local
+                  value: {{ .Values.kruize.env.local | quote }}
+              volumeMounts:
+                - name: kruize-config
+                  mountPath: /tmp/cdappconfig.json
+                  subPath: cdappconfig.json
+                  readOnly: true
+              resources:
+                {{- toYaml .Values.kruize.partitions.resources | nindent 16 }}
+          volumes:
+            - name: kruize-config
+              configMap:
+                name: {{ include "ros-ocp.fullname" . }}-kruize-config
+{{- end }}

--- a/deployment/kubernetes/helm/ros-ocp/templates/cronjob-kruize-partitions.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/cronjob-kruize-partitions.yaml
@@ -32,54 +32,54 @@ spec:
               image: "{{ .Values.kruize.image.repository }}:{{ .Values.kruize.image.tag }}"
               imagePullPolicy: {{ .Values.global.pullPolicy }}
               command: ["sh"]
-              args: ["-c", "export DB_CONFIG_FILE={{ .Values.kruize.env.DB_CONFIG_FILE }} && /home/autotune/app/target/bin/RetentionPartition"]
+              args: ["-c", "export DB_CONFIG_FILE={{ .Values.kruize.env.dbConfigFile }} && /home/autotune/app/target/bin/RetentionPartition"]
               env:
                 - name: START_AUTOTUNE
                   value: "false"
                 - name: LOGGING_LEVEL
-                  value: {{ .Values.kruize.partitions.env.LOGGING_LEVEL | quote }}
+                  value: {{ .Values.kruize.partitions.env.loggingLevel | quote }}
                 - name: ROOT_LOGGING_LEVEL
-                  value: {{ .Values.kruize.env.ROOT_LOGGING_LEVEL | quote }}
+                  value: {{ .Values.kruize.env.rootLoggingLevel | quote }}
                 - name: DB_CONFIG_FILE
-                  value: {{ .Values.kruize.env.DB_CONFIG_FILE | quote }}
+                  value: {{ .Values.kruize.env.dbConfigFile | quote }}
                 - name: dbdriver
-                  value: {{ .Values.kruize.env.dbdriver | quote }}
+                  value: {{ .Values.kruize.env.dbDriver | quote }}
                 - name: database_name
                   value: {{ .Values.database.kruize.name | quote }}
                 - name: clustertype
-                  value: {{ .Values.kruize.env.clustertype | quote }}
+                  value: {{ .Values.kruize.env.clusterType | quote }}
                 - name: k8stype
-                  value: {{ .Values.kruize.env.k8stype | quote }}
+                  value: {{ .Values.kruize.env.k8sType | quote }}
                 - name: authtype
-                  value: {{ .Values.kruize.env.authtype | quote }}
+                  value: {{ .Values.kruize.env.authType | quote }}
                 - name: monitoringagent
-                  value: {{ .Values.kruize.env.monitoringagent | quote }}
+                  value: {{ .Values.kruize.env.monitoringAgent | quote }}
                 - name: monitoringservice
-                  value: {{ .Values.kruize.env.monitoringservice | quote }}
+                  value: {{ .Values.kruize.env.monitoringService | quote }}
                 - name: monitoringendpoint
-                  value: {{ .Values.kruize.env.monitoringendpoint | quote }}
+                  value: {{ .Values.kruize.env.monitoringEndpoint | quote }}
                 - name: savetodb
-                  value: {{ .Values.kruize.env.savetodb | quote }}
+                  value: {{ .Values.kruize.env.saveToDb | quote }}
                 - name: hibernate_dialect
-                  value: {{ .Values.kruize.env.hibernate_dialect | quote }}
+                  value: {{ .Values.kruize.env.hibernateDialect | quote }}
                 - name: hibernate_driver
-                  value: {{ .Values.kruize.env.hibernate_driver | quote }}
+                  value: {{ .Values.kruize.env.hibernateDriver | quote }}
                 - name: hibernate_c3p0minsize
-                  value: {{ .Values.kruize.env.hibernate_c3p0minsize | quote }}
+                  value: {{ .Values.kruize.env.hibernateC3p0MinSize | quote }}
                 - name: hibernate_c3p0maxsize
-                  value: {{ .Values.kruize.env.hibernate_c3p0maxsize | quote }}
+                  value: {{ .Values.kruize.env.hibernateC3p0MaxSize | quote }}
                 - name: hibernate_c3p0timeout
-                  value: {{ .Values.kruize.env.hibernate_c3p0timeout | quote }}
+                  value: {{ .Values.kruize.env.hibernateC3p0Timeout | quote }}
                 - name: hibernate_c3p0maxstatements
-                  value: {{ .Values.kruize.env.hibernate_c3p0maxstatements | quote }}
+                  value: {{ .Values.kruize.env.hibernateC3p0MaxStatements | quote }}
                 - name: hibernate_hbm2ddlauto
-                  value: {{ .Values.kruize.env.hibernate_hbm2ddlauto | quote }}
+                  value: {{ .Values.kruize.env.hibernateHbm2ddlAuto | quote }}
                 - name: hibernate_showsql
-                  value: {{ .Values.kruize.env.hibernate_showsql | quote }}
+                  value: {{ .Values.kruize.env.hibernateShowSql | quote }}
                 - name: hibernate_timezone
-                  value: {{ .Values.kruize.env.hibernate_timezone | quote }}
+                  value: {{ .Values.kruize.env.hibernateTimezone | quote }}
                 - name: deletepartitionsthreshold
-                  value: {{ .Values.kruize.partitions.env.deletepartitionsthreshold | quote }}
+                  value: {{ .Values.kruize.partitions.env.deletePartitionsThreshold | quote }}
                 - name: local
                   value: {{ .Values.kruize.env.local | quote }}
               volumeMounts:

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-kruize.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-kruize.yaml
@@ -41,52 +41,52 @@ spec:
           image: "{{ .Values.kruize.image.repository }}:{{ .Values.kruize.image.tag }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command: ["sh"]
-          args: ["-c", "export DB_CONFIG_FILE={{ .Values.kruize.env.DB_CONFIG_FILE }} && /home/autotune/app/target/bin/CreatePartition"]
+          args: ["-c", "export DB_CONFIG_FILE={{ .Values.kruize.env.dbConfigFile }} && /home/autotune/app/target/bin/CreatePartition"]
           env:
             - name: START_AUTOTUNE
               value: "false"
             - name: LOGGING_LEVEL
-              value: {{ .Values.kruize.partitions.env.LOGGING_LEVEL | quote }}
+              value: {{ .Values.kruize.partitions.env.loggingLevel | quote }}
             - name: ROOT_LOGGING_LEVEL
-              value: {{ .Values.kruize.env.ROOT_LOGGING_LEVEL | quote }}
+              value: {{ .Values.kruize.env.rootLoggingLevel | quote }}
             - name: DB_CONFIG_FILE
-              value: {{ .Values.kruize.env.DB_CONFIG_FILE | quote }}
+              value: {{ .Values.kruize.env.dbConfigFile | quote }}
             - name: dbdriver
-              value: {{ .Values.kruize.env.dbdriver | quote }}
+              value: {{ .Values.kruize.env.dbDriver | quote }}
             - name: database_name
               value: {{ .Values.database.kruize.name | quote }}
             - name: clustertype
-              value: {{ .Values.kruize.env.clustertype | quote }}
+              value: {{ .Values.kruize.env.clusterType | quote }}
             - name: k8stype
-              value: {{ .Values.kruize.env.k8stype | quote }}
+              value: {{ .Values.kruize.env.k8sType | quote }}
             - name: authtype
-              value: {{ .Values.kruize.env.authtype | quote }}
+              value: {{ .Values.kruize.env.authType | quote }}
             - name: monitoringagent
-              value: {{ .Values.kruize.env.monitoringagent | quote }}
+              value: {{ .Values.kruize.env.monitoringAgent | quote }}
             - name: monitoringservice
-              value: {{ .Values.kruize.env.monitoringservice | quote }}
+              value: {{ .Values.kruize.env.monitoringService | quote }}
             - name: monitoringendpoint
-              value: {{ .Values.kruize.env.monitoringendpoint | quote }}
+              value: {{ .Values.kruize.env.monitoringEndpoint | quote }}
             - name: savetodb
-              value: {{ .Values.kruize.env.savetodb | quote }}
+              value: {{ .Values.kruize.env.saveToDb | quote }}
             - name: hibernate_dialect
-              value: {{ .Values.kruize.env.hibernate_dialect | quote }}
+              value: {{ .Values.kruize.env.hibernateDialect | quote }}
             - name: hibernate_driver
-              value: {{ .Values.kruize.env.hibernate_driver | quote }}
+              value: {{ .Values.kruize.env.hibernateDriver | quote }}
             - name: hibernate_c3p0minsize
-              value: {{ .Values.kruize.env.hibernate_c3p0minsize | quote }}
+              value: {{ .Values.kruize.env.hibernateC3p0MinSize | quote }}
             - name: hibernate_c3p0maxsize
-              value: {{ .Values.kruize.env.hibernate_c3p0maxsize | quote }}
+              value: {{ .Values.kruize.env.hibernateC3p0MaxSize | quote }}
             - name: hibernate_c3p0timeout
-              value: {{ .Values.kruize.env.hibernate_c3p0timeout | quote }}
+              value: {{ .Values.kruize.env.hibernateC3p0Timeout | quote }}
             - name: hibernate_c3p0maxstatements
-              value: {{ .Values.kruize.env.hibernate_c3p0maxstatements | quote }}
+              value: {{ .Values.kruize.env.hibernateC3p0MaxStatements | quote }}
             - name: hibernate_hbm2ddlauto
-              value: {{ .Values.kruize.env.hibernate_hbm2ddlauto | quote }}
+              value: {{ .Values.kruize.env.hibernateHbm2ddlAuto | quote }}
             - name: hibernate_showsql
-              value: {{ .Values.kruize.env.hibernate_showsql | quote }}
+              value: {{ .Values.kruize.env.hibernateShowSql | quote }}
             - name: hibernate_timezone
-              value: {{ .Values.kruize.env.hibernate_timezone | quote }}
+              value: {{ .Values.kruize.env.hibernateTimezone | quote }}
             - name: local
               value: {{ .Values.kruize.env.local | quote }}
           volumeMounts:
@@ -107,51 +107,51 @@ spec:
               protocol: TCP
           env:
             - name: LOGGING_LEVEL
-              value: {{ .Values.kruize.env.LOGGING_LEVEL | quote }}
+              value: {{ .Values.kruize.env.loggingLevel | quote }}
             - name: ROOT_LOGGING_LEVEL
-              value: {{ .Values.kruize.env.ROOT_LOGGING_LEVEL | quote }}
+              value: {{ .Values.kruize.env.rootLoggingLevel | quote }}
             - name: DB_CONFIG_FILE
-              value: {{ .Values.kruize.env.DB_CONFIG_FILE | quote }}
+              value: {{ .Values.kruize.env.dbConfigFile | quote }}
             - name: dbdriver
-              value: {{ .Values.kruize.env.dbdriver | quote }}
+              value: {{ .Values.kruize.env.dbDriver | quote }}
             - name: database_name
               value: {{ .Values.database.kruize.name | quote }}
             - name: clustertype
-              value: {{ .Values.kruize.env.clustertype | quote }}
+              value: {{ .Values.kruize.env.clusterType | quote }}
             - name: k8stype
-              value: {{ .Values.kruize.env.k8stype | quote }}
+              value: {{ .Values.kruize.env.k8sType | quote }}
             - name: authtype
-              value: {{ .Values.kruize.env.authtype | quote }}
+              value: {{ .Values.kruize.env.authType | quote }}
             - name: monitoringagent
-              value: {{ .Values.kruize.env.monitoringagent | quote }}
+              value: {{ .Values.kruize.env.monitoringAgent | quote }}
             - name: monitoringservice
-              value: {{ .Values.kruize.env.monitoringservice | quote }}
+              value: {{ .Values.kruize.env.monitoringService | quote }}
             - name: monitoringendpoint
-              value: {{ .Values.kruize.env.monitoringendpoint | quote }}
+              value: {{ .Values.kruize.env.monitoringEndpoint | quote }}
             - name: savetodb
-              value: {{ .Values.kruize.env.savetodb | quote }}
+              value: {{ .Values.kruize.env.saveToDb | quote }}
             - name: local
               value: {{ .Values.kruize.env.local | quote }}
             - name: LOG_ALL_HTTP_REQ_AND_RESPONSE
-              value: {{ .Values.kruize.env.LOG_ALL_HTTP_REQ_AND_RESPONSE | quote }}
+              value: {{ .Values.kruize.env.logAllHttpReqAndResponse | quote }}
             - name: hibernate_dialect
-              value: {{ .Values.kruize.env.hibernate_dialect | quote }}
+              value: {{ .Values.kruize.env.hibernateDialect | quote }}
             - name: hibernate_driver
-              value: {{ .Values.kruize.env.hibernate_driver | quote }}
+              value: {{ .Values.kruize.env.hibernateDriver | quote }}
             - name: hibernate_c3p0minsize
-              value: {{ .Values.kruize.env.hibernate_c3p0minsize | quote }}
+              value: {{ .Values.kruize.env.hibernateC3p0MinSize | quote }}
             - name: hibernate_c3p0maxsize
-              value: {{ .Values.kruize.env.hibernate_c3p0maxsize | quote }}
+              value: {{ .Values.kruize.env.hibernateC3p0MaxSize | quote }}
             - name: hibernate_c3p0timeout
-              value: {{ .Values.kruize.env.hibernate_c3p0timeout | quote }}
+              value: {{ .Values.kruize.env.hibernateC3p0Timeout | quote }}
             - name: hibernate_c3p0maxstatements
-              value: {{ .Values.kruize.env.hibernate_c3p0maxstatements | quote }}
+              value: {{ .Values.kruize.env.hibernateC3p0MaxStatements | quote }}
             - name: hibernate_hbm2ddlauto
-              value: {{ .Values.kruize.env.hibernate_hbm2ddlauto | quote }}
+              value: {{ .Values.kruize.env.hibernateHbm2ddlAuto | quote }}
             - name: hibernate_showsql
-              value: {{ .Values.kruize.env.hibernate_showsql | quote }}
+              value: {{ .Values.kruize.env.hibernateShowSql | quote }}
             - name: hibernate_timezone
-              value: {{ .Values.kruize.env.hibernate_timezone | quote }}
+              value: {{ .Values.kruize.env.hibernateTimezone | quote }}
             - name: plots
               value: {{ .Values.kruize.env.plots | quote }}
           volumeMounts:

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-kruize.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-kruize.yaml
@@ -36,6 +36,67 @@ spec:
                 sleep 5
               done
               echo "Kruize database is ready"
+        {{- if .Values.kruize.partitions.createEnabled }}
+        - name: create-kruize-partitions
+          image: "{{ .Values.kruize.image.repository }}:{{ .Values.kruize.image.tag }}"
+          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          command: ["sh"]
+          args: ["-c", "export DB_CONFIG_FILE={{ .Values.kruize.env.DB_CONFIG_FILE }} && /home/autotune/app/target/bin/CreatePartition"]
+          env:
+            - name: START_AUTOTUNE
+              value: "false"
+            - name: LOGGING_LEVEL
+              value: {{ .Values.kruize.partitions.env.LOGGING_LEVEL | quote }}
+            - name: ROOT_LOGGING_LEVEL
+              value: {{ .Values.kruize.env.ROOT_LOGGING_LEVEL | quote }}
+            - name: DB_CONFIG_FILE
+              value: {{ .Values.kruize.env.DB_CONFIG_FILE | quote }}
+            - name: dbdriver
+              value: {{ .Values.kruize.env.dbdriver | quote }}
+            - name: database_name
+              value: {{ .Values.database.kruize.name | quote }}
+            - name: clustertype
+              value: {{ .Values.kruize.env.clustertype | quote }}
+            - name: k8stype
+              value: {{ .Values.kruize.env.k8stype | quote }}
+            - name: authtype
+              value: {{ .Values.kruize.env.authtype | quote }}
+            - name: monitoringagent
+              value: {{ .Values.kruize.env.monitoringagent | quote }}
+            - name: monitoringservice
+              value: {{ .Values.kruize.env.monitoringservice | quote }}
+            - name: monitoringendpoint
+              value: {{ .Values.kruize.env.monitoringendpoint | quote }}
+            - name: savetodb
+              value: {{ .Values.kruize.env.savetodb | quote }}
+            - name: hibernate_dialect
+              value: {{ .Values.kruize.env.hibernate_dialect | quote }}
+            - name: hibernate_driver
+              value: {{ .Values.kruize.env.hibernate_driver | quote }}
+            - name: hibernate_c3p0minsize
+              value: {{ .Values.kruize.env.hibernate_c3p0minsize | quote }}
+            - name: hibernate_c3p0maxsize
+              value: {{ .Values.kruize.env.hibernate_c3p0maxsize | quote }}
+            - name: hibernate_c3p0timeout
+              value: {{ .Values.kruize.env.hibernate_c3p0timeout | quote }}
+            - name: hibernate_c3p0maxstatements
+              value: {{ .Values.kruize.env.hibernate_c3p0maxstatements | quote }}
+            - name: hibernate_hbm2ddlauto
+              value: {{ .Values.kruize.env.hibernate_hbm2ddlauto | quote }}
+            - name: hibernate_showsql
+              value: {{ .Values.kruize.env.hibernate_showsql | quote }}
+            - name: hibernate_timezone
+              value: {{ .Values.kruize.env.hibernate_timezone | quote }}
+            - name: local
+              value: {{ .Values.kruize.env.local | quote }}
+          volumeMounts:
+            - name: kruize-config
+              mountPath: /tmp/cdappconfig.json
+              subPath: cdappconfig.json
+              readOnly: true
+          resources:
+            {{- toYaml .Values.kruize.partitions.resources | nindent 12 }}
+        {{- end }}
       containers:
         - name: kruize
           image: "{{ .Values.kruize.image.repository }}:{{ .Values.kruize.image.tag }}"
@@ -54,7 +115,7 @@ spec:
             - name: dbdriver
               value: {{ .Values.kruize.env.dbdriver | quote }}
             - name: database_name
-              value: {{ .Values.kruize.env.database_name | quote }}
+              value: {{ .Values.database.kruize.name | quote }}
             - name: clustertype
               value: {{ .Values.kruize.env.clustertype | quote }}
             - name: k8stype

--- a/deployment/kubernetes/helm/ros-ocp/templates/secret-db-credentials.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/secret-db-credentials.yaml
@@ -8,5 +8,5 @@ metadata:
 type: Opaque
 data:
   ros-password: {{ .Values.database.ros.env.POSTGRES_PASSWORD | b64enc }}
-  kruize-password: {{ .Values.database.kruize.env.POSTGRES_PASSWORD | b64enc }}
+  kruize-password: {{ .Values.database.kruize.password | b64enc }}
   sources-password: {{ .Values.database.sources.env.POSTGRES_PASSWORD | b64enc }}

--- a/deployment/kubernetes/helm/ros-ocp/templates/statefulset-db-kruize.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/statefulset-db-kruize.yaml
@@ -36,9 +36,9 @@ spec:
               protocol: TCP
           env:
             - name: POSTGRES_DB
-              value: {{ .Values.database.kruize.env.POSTGRES_DB | quote }}
+              value: {{ .Values.database.kruize.name | quote }}
             - name: POSTGRES_USER
-              value: {{ .Values.database.kruize.env.POSTGRES_USER | quote }}
+              value: {{ .Values.database.kruize.username | quote }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -54,7 +54,7 @@ spec:
               command:
                 - pg_isready
                 - -U
-                - {{ .Values.database.kruize.env.POSTGRES_USER }}
+                - {{ .Values.database.kruize.username }}
             initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
@@ -64,7 +64,7 @@ spec:
               command:
                 - pg_isready
                 - -U
-                - {{ .Values.database.kruize.env.POSTGRES_USER }}
+                - {{ .Values.database.kruize.username }}
             initialDelaySeconds: 5
             periodSeconds: {{ .Values.probes.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.timeoutSeconds }}

--- a/deployment/kubernetes/helm/ros-ocp/values.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/values.yaml
@@ -39,6 +39,14 @@ database:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     port: 5432
+    # Database configuration for kruize configmap
+    host: internal  # Use "internal" for the built-in database service, or specify external hostname
+    name: postgres
+    username: postgres
+    password: postgres
+    adminUsername: postgres
+    adminPassword: postgres
+    sslMode: disable
 
   sources:
     enabled: true
@@ -191,6 +199,29 @@ kruize:
     hibernate_showsql: false
     hibernate_timezone: UTC
     plots: true
+  # Partition management configuration
+  partitions:
+    # Enable partition creation as initContainer
+    createEnabled: true
+    # Enable partition deletion CronJob
+    deleteEnabled: true
+    # Schedule for partition deletion CronJob (daily at midnight)
+    deleteSchedule: "0 0 * * *"
+    # Job history limits
+    successfulJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 1
+    # Environment variables specific to partition jobs
+    env:
+      LOGGING_LEVEL: info
+      deletepartitionsthreshold: "16"
+    # Resource limits for partition jobs
+    resources:
+      requests:
+        memory: "256Mi"
+        cpu: "100m"
+      limits:
+        memory: "512Mi"
+        cpu: "300m"
 
 # ROS-OCP Backend Services
 rosocp:

--- a/deployment/kubernetes/helm/ros-ocp/values.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/values.yaml
@@ -175,29 +175,28 @@ kruize:
     tag: "d0b4337"
   port: 8080
   env:
-    LOGGING_LEVEL: debug
-    ROOT_LOGGING_LEVEL: error
-    DB_CONFIG_FILE: /tmp/cdappconfig.json
-    dbdriver: "jdbc:postgresql://"
-    database_name: postgres
-    clustertype: kubernetes
-    k8stype: openshift
-    authtype: ""
-    monitoringagent: prometheus
-    monitoringservice: prometheus-k8s
-    monitoringendpoint: prometheus-k8s
-    savetodb: true
+    loggingLevel: debug
+    rootLoggingLevel: error
+    dbConfigFile: /tmp/cdappconfig.json
+    dbDriver: "jdbc:postgresql://"
+    clusterType: kubernetes
+    k8sType: openshift
+    authType: ""
+    monitoringAgent: prometheus
+    monitoringService: prometheus-k8s
+    monitoringEndpoint: prometheus-k8s
+    saveToDb: true
     local: false
-    LOG_ALL_HTTP_REQ_AND_RESPONSE: true
-    hibernate_dialect: org.hibernate.dialect.PostgreSQLDialect
-    hibernate_driver: org.postgresql.Driver
-    hibernate_c3p0minsize: 2
-    hibernate_c3p0maxsize: 5
-    hibernate_c3p0timeout: 300
-    hibernate_c3p0maxstatements: 100
-    hibernate_hbm2ddlauto: none
-    hibernate_showsql: false
-    hibernate_timezone: UTC
+    logAllHttpReqAndResponse: true
+    hibernateDialect: org.hibernate.dialect.PostgreSQLDialect
+    hibernateDriver: org.postgresql.Driver
+    hibernateC3p0MinSize: 2
+    hibernateC3p0MaxSize: 5
+    hibernateC3p0Timeout: 300
+    hibernateC3p0MaxStatements: 100
+    hibernateHbm2ddlAuto: none
+    hibernateShowSql: false
+    hibernateTimezone: UTC
     plots: true
   # Partition management configuration
   partitions:
@@ -212,8 +211,8 @@ kruize:
     failedJobsHistoryLimit: 1
     # Environment variables specific to partition jobs
     env:
-      LOGGING_LEVEL: info
-      deletepartitionsthreshold: "16"
+      loggingLevel: info
+      deletePartitionsThreshold: "16"
     # Resource limits for partition jobs
     resources:
       requests:


### PR DESCRIPTION
The Kruize deployment should have additional two jobs: one-shot for creating partitions and a scheduled job for deleting partitions. 

This PR adds missing jobs and also standardise the use of the kruize values. 