### PR TITLE
FLPATH-2683: nginx fails to deploy in KIND with non-privileged ports

### DIFF
--- a/deployment/kubernetes/scripts/deploy-kind.sh
+++ b/deployment/kubernetes/scripts/deploy-kind.sh
@@ -129,10 +129,10 @@ nodes:
       kubeletExtraArgs:
         node-labels: "ingress-ready=true"
   extraPortMappings:
-  - containerPort: 30080
+  - containerPort: 80
     hostPort: 30080
     protocol: TCP
-  - containerPort: 30443
+  - containerPort: 443
     hostPort: 30443
     protocol: TCP
   - containerPort: 30081
@@ -498,7 +498,7 @@ debug_ingress_curl() {
 
     kill $PORT_FWD_PID
     echo_info "end port forwarding"
-    
+
     local ingress_pod
     kubectl wait --namespace ingress-nginx --for=condition=ready pod -l app.kubernetes.io/component=controller --timeout=60s
     # Then get pod name safely


### PR DESCRIPTION
The nginx ingress controller deployment fails in KIND clusters configured for non-privileged ports due to a combination of hostPort binding conflicts and resource exhaustion issues. 
The KIND-specific nginx deployment attempts to bind directly to privileged ports 80/443, which creates networking mismatches when KIND is configured to use non-privileged ports 7080/7443. 
The default nginx configuration spawns multiple worker processes that exceed the pthread allocation limits in KIND's resource-constrained container environment, resulting in `pthread_create() failed (11: Resource temporarily unavailable) ` errors that cause the controller pods to crash-loop

## Documentation update? :memo:

- [ x ] Yes
- [ ] No

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [x ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added
