### PR TITLE
[FLPATH-2670] Configure Kruize for local deployment

### DIFF
--- a/.github/workflows/helm-chart-test.yml
+++ b/.github/workflows/helm-chart-test.yml
@@ -1,5 +1,11 @@
 name: Helm Chart Quality Test
 
+# This workflow tests the ROS-OCP Helm chart deployment on Kind
+# Uses alternative registries to avoid Docker Hub rate limiting:
+# - public.ecr.aws for official images (postgres, redis, busybox, confluent)
+# - quay.io for application images (already configured)
+# - ghcr.io as fallback for some images
+
 on:
   pull_request:
     paths:
@@ -17,27 +23,102 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Public ECR
+        run: |
+          # Login to public.ecr.aws (no authentication required for public images, but login for higher rate limits)
+          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws 2>/dev/null || echo "Public ECR login failed, continuing without auth"
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+
+      - name: Verify Docker is running
+        run: |
+          echo "Docker version:"
+          docker --version
+          echo "Docker info:"
+          docker info
+          echo "Docker daemon status:"
+          docker system info --format '{{.ServerVersion}}'
+          echo "Testing Docker connectivity:"
+          docker run --rm hello-world
+
       - name: Install KIND
         run: |
+          # Download and install Kind v0.20.0 (stable version)
           curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
+
+          # Verify installation
+          kind version
+
+          # Configure Kind to use Docker explicitly
+          echo "Docker driver will be used by Kind"
 
       - name: Install kubectl
         run: |
           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
           chmod +x kubectl
           sudo mv kubectl /usr/local/bin/kubectl
+          kubectl version --client
 
       - name: Install Helm
         run: |
           curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          helm version
 
-      - name: Set up environment
+      - name: Set up environment and Docker configuration
         run: |
           echo "KIND_CLUSTER_NAME=ros-ocp-test-cluster" >> $GITHUB_ENV
           echo "HELM_RELEASE_NAME=ros-ocp-test" >> $GITHUB_ENV
           echo "NAMESPACE=ros-ocp-test" >> $GITHUB_ENV
+
+          # Ensure Docker daemon is accessible
+          echo "Current user: $(whoami)"
+          echo "Docker group members:"
+          getent group docker || echo "Docker group not found"
+
+          # Set Docker environment variables for Kind
+          echo "DOCKER_HOST=" >> $GITHUB_ENV
+          echo "KIND_EXPERIMENTAL_DOCKER_NETWORK=bridge" >> $GITHUB_ENV
+
+      - name: Pre-pull required Docker images
+        run: |
+          echo "Pre-pulling essential images from alternative registries to avoid docker.io rate limits..."
+
+          # Use Kind's official registry mirror when available
+          docker pull kindest/node:v1.27.3 &
+
+          # Use public.ecr.aws mirrors when available, fallback to docker.io
+          docker pull public.ecr.aws/docker/library/postgres:13 || docker pull postgres:13 &
+          docker pull public.ecr.aws/docker/library/redis:7-alpine || docker pull redis:7-alpine &
+
+          # Quay.io images (already using alternative registry)
+          docker pull quay.io/minio/minio:latest &
+
+          # Confluent images (try GitHub Container Registry first)
+          docker pull ghcr.io/confluentinc/cp-kafka:7.5.3 || docker pull confluentinc/cp-kafka:7.5.3 &
+          docker pull ghcr.io/confluentinc/cp-zookeeper:7.4.10 || docker pull confluentinc/cp-zookeeper:7.4.10 &
+
+          wait
+          echo "Image pre-pulling completed"
+
+      - name: Clean up any existing Kind clusters
+        run: |
+          # Clean up any existing clusters to avoid conflicts
+          kind get clusters | xargs -I {} kind delete cluster --name {} || true
+          docker system prune -f || true
 
       - name: Deploy KIND cluster and Helm chart
         run: |
@@ -45,15 +126,47 @@ jobs:
           export KIND_CLUSTER_NAME=${{ env.KIND_CLUSTER_NAME }}
           export HELM_RELEASE_NAME=${{ env.HELM_RELEASE_NAME }}
           export NAMESPACE=${{ env.NAMESPACE }}
+
+          # Make script executable
           chmod +x deploy-kind.sh
+
+          # Run deployment with verbose output
+          echo "Starting KIND cluster deployment..."
           ./deploy-kind.sh
+
+          # Verify cluster is running
+          echo "Verifying cluster status..."
+          kind get clusters
+          kubectl cluster-info
+          kubectl get nodes -o wide
 
       - name: Wait for services to stabilize
         run: |
           echo "Waiting for services to stabilize..."
-          sleep 60
+
+          # Wait for all pods to be in Running state
+          timeout 600 bash -c "until kubectl wait --for=condition=ready pod -l 'app.kubernetes.io/instance=${{ env.HELM_RELEASE_NAME }}' -n ${{ env.NAMESPACE }} --timeout=30s; do echo 'Waiting for pods...'; sleep 10; done"
+
+          # Additional wait for services to fully initialize
+          echo "All pods ready, waiting additional 30 seconds for service initialization..."
+          sleep 30
+
+      - name: Verify cluster and services health
+        run: |
+          echo "=== Cluster Health Check ==="
+          kubectl get nodes -o wide
+          kubectl get pods -n ${{ env.NAMESPACE }} -o wide
+          kubectl get services -n ${{ env.NAMESPACE }}
+
+          echo "=== Docker Container Status ==="
+          docker ps --filter "label=io.x-k8s.kind.cluster=${{ env.KIND_CLUSTER_NAME }}"
+
+          echo "=== Resource Usage ==="
+          df -h
+          free -h
 
       - name: Run dataflow test
+        timeout-minutes: 15
         run: |
           cd deployment/kubernetes/scripts
           export KIND_CLUSTER_NAME=${{ env.KIND_CLUSTER_NAME }}
@@ -65,19 +178,55 @@ jobs:
       - name: Show cluster status on failure
         if: failure()
         run: |
+          echo "=== Docker Status ==="
+          docker --version || true
+          docker info || true
+          docker ps -a || true
+          docker images | head -10 || true
+
+          echo "=== Kind Status ==="
+          kind version || true
+          kind get clusters || true
+
           echo "=== Cluster Status ==="
           kubectl cluster-info || true
+          kubectl version || true
+
           echo "=== Pods Status ==="
           kubectl get pods -n ${{ env.NAMESPACE }} -o wide || true
+          kubectl get pods --all-namespaces | head -20 || true
+
           echo "=== Services Status ==="
           kubectl get services -n ${{ env.NAMESPACE }} || true
+
           echo "=== Events ==="
           kubectl get events -n ${{ env.NAMESPACE }} --sort-by='.lastTimestamp' || true
+          kubectl get events --all-namespaces --sort-by='.lastTimestamp' | head -20 || true
+
+          echo "=== Persistent Volumes ==="
+          kubectl get pv,pvc -n ${{ env.NAMESPACE }} || true
+
+          echo "=== Node Status ==="
+          kubectl get nodes -o wide || true
+          kubectl describe nodes || true
+
           echo "=== Recent Logs ==="
           for pod in $(kubectl get pods -n ${{ env.NAMESPACE }} -o name | head -5); do
             echo "--- Logs for $pod ---"
             kubectl logs -n ${{ env.NAMESPACE }} $pod --tail=20 || true
+            kubectl logs -n ${{ env.NAMESPACE }} $pod --previous --tail=10 || true
           done
+
+          echo "=== Docker Container Logs ==="
+          for container in $(docker ps --filter "label=io.x-k8s.kind.cluster=${{ env.KIND_CLUSTER_NAME }}" --format "{{.Names}}" | head -3); do
+            echo "--- Docker logs for $container ---"
+            docker logs $container --tail=20 || true
+          done
+
+          echo "=== System Resources ==="
+          df -h || true
+          free -h || true
+          top -bn1 | head -20 || true
 
       - name: Cleanup
         if: always()

--- a/deployment/kubernetes/helm/ros-ocp/templates/auth-cluster-roles-rosocp-api.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/auth-cluster-roles-rosocp-api.yaml
@@ -7,6 +7,9 @@ rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
   verbs: ["create"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-ingress.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-ingress.yaml
@@ -27,24 +27,28 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-minio
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-minio {{ .Values.minio.ports.api }}; do
-                echo "Waiting for MinIO..."
+              echo "Waiting for MinIO at {{ include "ros-ocp.fullname" . }}-minio:{{ .Values.minio.ports.api }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-minio/{{ .Values.minio.ports.api }}" 2>/dev/null; do
+                echo "MinIO not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
               echo "MinIO is ready"
+              echo "MinIO is ready"
         - name: wait-for-kafka
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-kafka {{ .Values.kafka.broker.port }}; do
-                echo "Waiting for Kafka..."
+              echo "Waiting for Kafka at {{ include "ros-ocp.fullname" . }}-kafka:{{ .Values.kafka.broker.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-kafka/{{ .Values.kafka.broker.port }}" 2>/dev/null; do
+                echo "Kafka not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
+              echo "Kafka is ready"
               echo "Kafka is ready"
       containers:
         - name: ingress

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-kruize.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-kruize.yaml
@@ -27,12 +27,13 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-db-kruize
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-db-kruize {{ .Values.database.kruize.port }}; do
-                echo "Waiting for Kruize database..."
+              echo "Waiting for Kruize database at {{ include "ros-ocp.fullname" . }}-db-kruize:{{ .Values.database.kruize.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-db-kruize/{{ .Values.database.kruize.port }}" 2>/dev/null; do
+                echo "Database not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
               echo "Kruize database is ready"

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-api.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-api.yaml
@@ -28,24 +28,28 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-db-ros
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-db-ros {{ .Values.database.ros.port }}; do
-                echo "Waiting for ROS database..."
+              echo "Waiting for ROS database at {{ include "ros-ocp.fullname" . }}-db-ros:{{ .Values.database.ros.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-db-ros/{{ .Values.database.ros.port }}" 2>/dev/null; do
+                echo "Database not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
               echo "ROS database is ready"
+              echo "ROS database is ready"
         - name: wait-for-kafka
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-kafka {{ .Values.kafka.broker.port }}; do
-                echo "Waiting for Kafka..."
+              echo "Waiting for Kafka at {{ include "ros-ocp.fullname" . }}-kafka:{{ .Values.kafka.broker.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-kafka/{{ .Values.kafka.broker.port }}" 2>/dev/null; do
+                echo "Kafka not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
+              echo "Kafka is ready"
               echo "Kafka is ready"
       containers:
         - name: rosocp-api

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-housekeeper.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-housekeeper.yaml
@@ -27,44 +27,52 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-db-ros
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-db-ros {{ .Values.database.ros.port }}; do
-                echo "Waiting for ROS database..."
+              echo "Waiting for ROS database at {{ include "ros-ocp.fullname" . }}-db-ros:{{ .Values.database.ros.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-db-ros/{{ .Values.database.ros.port }}" 2>/dev/null; do
+                echo "Database not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
               echo "ROS database is ready"
+              echo "ROS database is ready"
         - name: wait-for-kafka
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-kafka {{ .Values.kafka.broker.port }}; do
-                echo "Waiting for Kafka..."
+              echo "Waiting for Kafka at {{ include "ros-ocp.fullname" . }}-kafka:{{ .Values.kafka.broker.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-kafka/{{ .Values.kafka.broker.port }}" 2>/dev/null; do
+                echo "Kafka not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
               echo "Kafka is ready"
+              echo "Kafka is ready"
         - name: wait-for-kruize
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-kruize {{ .Values.kruize.port }}; do
-                echo "Waiting for Kruize..."
+              echo "Waiting for Kruize at {{ include "ros-ocp.fullname" . }}-kruize:{{ .Values.kruize.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-kruize/{{ .Values.kruize.port }}" 2>/dev/null; do
+                echo "Kruize not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
               echo "Kruize is ready"
+              echo "Kruize is ready"
         - name: wait-for-sources-api
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-sources-api {{ .Values.sourcesApi.port }}; do
-                echo "Waiting for Sources API..."
+              echo "Waiting for Sources API at {{ include "ros-ocp.fullname" . }}-sources-api:{{ .Values.sourcesApi.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-sources-api/{{ .Values.sourcesApi.port }}" 2>/dev/null; do
+                echo "Sources API not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
+              echo "Sources API is ready"
               echo "Sources API is ready"
       containers:
         - name: rosocp-housekeeper

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-processor.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-processor.yaml
@@ -27,34 +27,40 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-db-ros
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-db-ros {{ .Values.database.ros.port }}; do
-                echo "Waiting for ROS database..."
+              echo "Waiting for ROS database at {{ include "ros-ocp.fullname" . }}-db-ros:{{ .Values.database.ros.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-db-ros/{{ .Values.database.ros.port }}" 2>/dev/null; do
+                echo "Database not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
               echo "ROS database is ready"
+              echo "ROS database is ready"
         - name: wait-for-kafka
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-kafka {{ .Values.kafka.broker.port }}; do
-                echo "Waiting for Kafka..."
+              echo "Waiting for Kafka at {{ include "ros-ocp.fullname" . }}-kafka:{{ .Values.kafka.broker.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-kafka/{{ .Values.kafka.broker.port }}" 2>/dev/null; do
+                echo "Kafka not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
               echo "Kafka is ready"
+              echo "Kafka is ready"
         - name: wait-for-kruize
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-kruize {{ .Values.kruize.port }}; do
-                echo "Waiting for Kruize..."
+              echo "Waiting for Kruize at {{ include "ros-ocp.fullname" . }}-kruize:{{ .Values.kruize.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-kruize/{{ .Values.kruize.port }}" 2>/dev/null; do
+                echo "Kruize not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
+              echo "Kruize is ready"
               echo "Kruize is ready"
       containers:
         - name: rosocp-processor

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-recommendation-poller.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-rosocp-recommendation-poller.yaml
@@ -27,34 +27,40 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-db-ros
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-db-ros {{ .Values.database.ros.port }}; do
-                echo "Waiting for ROS database..."
+              echo "Waiting for ROS database at {{ include "ros-ocp.fullname" . }}-db-ros:{{ .Values.database.ros.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-db-ros/{{ .Values.database.ros.port }}" 2>/dev/null; do
+                echo "Database not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
               echo "ROS database is ready"
+              echo "ROS database is ready"
         - name: wait-for-kafka
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-kafka {{ .Values.kafka.broker.port }}; do
-                echo "Waiting for Kafka..."
+              echo "Waiting for Kafka at {{ include "ros-ocp.fullname" . }}-kafka:{{ .Values.kafka.broker.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-kafka/{{ .Values.kafka.broker.port }}" 2>/dev/null; do
+                echo "Kafka not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
               echo "Kafka is ready"
+              echo "Kafka is ready"
         - name: wait-for-kruize
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-kruize {{ .Values.kruize.port }}; do
-                echo "Waiting for Kruize..."
+              echo "Waiting for Kruize at {{ include "ros-ocp.fullname" . }}-kruize:{{ .Values.kruize.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-kruize/{{ .Values.kruize.port }}" 2>/dev/null; do
+                echo "Kruize not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
+              echo "Kruize is ready"
               echo "Kruize is ready"
       containers:
         - name: rosocp-recommendation-poller

--- a/deployment/kubernetes/helm/ros-ocp/templates/deployment-sources-api.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/deployment-sources-api.yaml
@@ -27,34 +27,40 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-db-sources
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.sourcesDatabaseHost" . }} {{ .Values.database.sources.port }}; do
-                echo "Waiting for Sources database..."
+              echo "Waiting for Sources database at {{ include "ros-ocp.sourcesDatabaseHost" . }}:{{ .Values.database.sources.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.sourcesDatabaseHost" . }}/{{ .Values.database.sources.port }}" 2>/dev/null; do
+                echo "Database not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
               echo "Sources database is ready"
+              echo "Sources database is ready"
         - name: wait-for-kafka
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-kafka {{ .Values.kafka.broker.port }}; do
-                echo "Waiting for Kafka..."
+              echo "Waiting for Kafka at {{ include "ros-ocp.fullname" . }}-kafka:{{ .Values.kafka.broker.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-kafka/{{ .Values.kafka.broker.port }}" 2>/dev/null; do
+                echo "Kafka not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
               echo "Kafka is ready"
+              echo "Kafka is ready"
         - name: wait-for-redis
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-redis {{ .Values.redis.port }}; do
-                echo "Waiting for Redis..."
+              echo "Waiting for Redis at {{ include "ros-ocp.fullname" . }}-redis:{{ .Values.redis.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-redis/{{ .Values.redis.port }}" 2>/dev/null; do
+                echo "Redis not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
+              echo "Redis is ready"
               echo "Redis is ready"
       containers:
         - name: sources-api

--- a/deployment/kubernetes/helm/ros-ocp/templates/job-kafka-topics.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/job-kafka-topics.yaml
@@ -20,12 +20,13 @@ spec:
       restartPolicy: OnFailure
       initContainers:
         - name: wait-for-kafka
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-kafka {{ .Values.kafka.broker.port }}; do
-                echo "Waiting for Kafka..."
+              echo "Waiting for Kafka at {{ include "ros-ocp.fullname" . }}-kafka:{{ .Values.kafka.broker.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-kafka/{{ .Values.kafka.broker.port }}" 2>/dev/null; do
+                echo "Kafka not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
               echo "Kafka is ready"

--- a/deployment/kubernetes/helm/ros-ocp/templates/job-minio-buckets.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/templates/job-minio-buckets.yaml
@@ -20,18 +20,19 @@ spec:
       restartPolicy: OnFailure
       initContainers:
         - name: wait-for-minio
-          image: busybox:1.35
-          command: ['sh', '-c']
+          image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
+          command: ['bash', '-c']
           args:
             - |
-              until nc -z {{ include "ros-ocp.fullname" . }}-minio {{ .Values.minio.ports.api }}; do
-                echo "Waiting for MinIO..."
+              echo "Waiting for MinIO at {{ include "ros-ocp.fullname" . }}-minio:{{ .Values.minio.ports.api }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-minio/{{ .Values.minio.ports.api }}" 2>/dev/null; do
+                echo "MinIO not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
               echo "MinIO is ready"
       containers:
         - name: minio-buckets
-          image: minio/mc:RELEASE.2025-07-21T05-28-08Z
+          image: "{{ .Values.global.initContainers.minioMc.repository }}:{{ .Values.global.initContainers.minioMc.tag }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           env:
             - name: MINIO_ACCESS_KEY

--- a/deployment/kubernetes/helm/ros-ocp/values.yaml
+++ b/deployment/kubernetes/helm/ros-ocp/values.yaml
@@ -7,6 +7,14 @@ global:
   pullPolicy: IfNotPresent
   # Pull secrets for private registries
   imagePullSecrets: []
+  # Init container images (using alternative registries to avoid docker.io rate limits)
+  initContainers:
+    waitFor:
+      repository: registry.access.redhat.com/ubi9/ubi-minimal
+      tag: "latest"
+    minioMc:
+      repository: quay.io/minio/mc
+      tag: "RELEASE.2025-07-21T05-28-08Z"
 
 serviceAccount:
   name: ros-ocp-backend
@@ -54,11 +62,11 @@ database:
     username: postgres
     password: postgres
 
-# Kafka and Zookeeper
+# Kafka and Zookeeper (using insights-onprem images)
 kafka:
   zookeeper:
     image:
-      repository: confluentinc/cp-zookeeper
+      repository: quay.io/insights-onprem/cp-zookeeper  # Variable for future updates
       tag: "7.4.10"
     clientPort: 32181
     serverId: 1
@@ -66,7 +74,7 @@ kafka:
       size: 5Gi
   broker:
     image:
-      repository: confluentinc/cp-kafka
+      repository: quay.io/insights-onprem/cp-kafka  # Variable for future updates
       tag: "7.5.3"
     brokerId: 1
     offsetsTopicReplicationFactor: 1
@@ -147,11 +155,11 @@ kruize:
     clusterType: kubernetes
     k8sType: openshift
     authType: ""
-    monitoringAgent: prometheus
-    monitoringService: prometheus-k8s
-    monitoringEndpoint: prometheus-k8s
+    monitoringAgent: "prometheus"
+    monitoringService: "prometheus"
+    monitoringEndpoint: "prometheus"
     saveToDb: true
-    local: false
+    local: true
     logAllHttpReqAndResponse: true
     hibernateDialect: org.hibernate.dialect.PostgreSQLDialect
     hibernateDriver: org.postgresql.Driver


### PR DESCRIPTION
- Fix ingress deployment failure
- Reduce file watches to avoid error failed to create fsnotify watcher: too many open files
- use nginx version 1.8.1
- Enable debug for the nginx containers
- add wait for kube api to be ready before deploying nginx and set monitoring fields to none instead of empty
- Use single node in kind to resolve node connectivity limitations in a rootless podman
- Use docker instead of podman to fix the network limitations between containers with kind
- Remove nginx start leftovers
- Use monitoring endpoint for kruize as prometheus
- Use ubi9 to replace busybox in kruize
- Add daemonset RBAC to kruize SA and generate sample data with current timestamp
- Add more sample data for kruize
- Replace references to docker.io to use other repositories with less pull restrictions
- Use non-docker.io registry for images
