### PR TITLE
Fix Helm chart download when multiple .tgz assets exist

### DIFF
--- a/deployment/kubernetes/scripts/install-helm-chart.sh
+++ b/deployment/kubernetes/scripts/install-helm-chart.sh
@@ -168,8 +168,8 @@ download_latest_chart() {
 
     # Extract the tag name and download URL for the .tgz file
     local tag_name=$(echo "$latest_release" | jq -r '.tag_name')
-    local download_url=$(echo "$latest_release" | jq -r '.assets[] | select(.name | endswith(".tgz")) | .browser_download_url')
-    local filename=$(echo "$latest_release" | jq -r '.assets[] | select(.name | endswith(".tgz")) | .name')
+    local download_url=$(echo "$latest_release" | jq -r '.assets[] | select(.name | contains("latest") and endswith(".tgz")) | .browser_download_url')
+    local filename=$(echo "$latest_release" | jq -r '.assets[] | select(.name | contains("latest") and endswith(".tgz")) | .name')
 
     if [ -z "$download_url" ] || [ "$download_url" = "null" ]; then
         echo_error "No .tgz file found in the latest release ($tag_name)"


### PR DESCRIPTION
## Problem

When running `install-helm-chart.sh`, the script failed during chart download with:
```
curl: (3) URL rejected: Malformed input to a URL function
[ERROR] Failed to download chart from GitHub
```

## Root Cause

The GitHub release contains two .tgz assets:
- `ros-ocp-0.1.1.tgz` (versioned chart)
- `ros-ocp-latest.tgz` (latest alias)

The jq filter `select(.name | endswith(".tgz"))` matched **both** files, causing `$download_url` to contain two URLs separated by a newline instead of a single URL. When curl attempted to download using this multi-line string, it failed with a malformed URL error.

## Solution

Updated the jq filter to specifically select only the latest.tgz asset:
```bash
select(.name | contains("latest") and endswith(".tgz"))
```

This ensures `$download_url` contains only one URL, allowing the download to succeed.

Jira: FLPATH-2758