### PR TITLE
Fix to enable a successful build and push when a PR is merged

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -15,9 +15,6 @@ on:
       - 'rosocp.go'
       - 'openapi.json'
       - 'resource_optimization_openshift.json'
-  pull_request:
-    branches: [ main ]
-    types: [ closed ]
   workflow_dispatch:
     inputs:
       tag:
@@ -33,7 +30,6 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Problem

The build-and-push workflow was failing with Quay.io login errors when triggered from pull requests. The issue was that organization secrets are only available on the main branch, but the workflow was configured to run on pull request branches where these secrets are not accessible.

## Root Cause

The workflow had a pull_request trigger with types: [closed] that was causing it to run in the context of the PR branch rather than the main branch.

## Solution

This PR fixes the issue by removing the pull_request trigger and keeping only push to main and workflow_dispatch triggers, ensuring organization secrets are always available.

## Benefits

- Reliable Builds: No more secret access failures
- Proper Security: Secrets only used in appropriate contexts  
- Cleaner Workflow: Simplified triggers and conditions
- CI/CD Best Practice: Build and push only after code is on main branch

Signed-off-by: Jordi Gil <jgil@redhat.com>
