### PR TITLE
Remove sources-api-go Dependency for On-Prem Deployments

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,9 @@ type Config struct {
 	// Sources-api-go config
 	SourceApiBaseUrl string `mapstructure:"SOURCES_API_BASE_URL"`
 	SourceApiPrefix  string `mapstructure:"SOURCES_API_PREFIX"`
+
+	// On-prem deployment config
+	RosOnPremDeployment bool `mapstructure:"ROS_ONPREM_DEPLOYMENT"`
 }
 
 var cfg *Config = nil
@@ -166,6 +169,7 @@ func initConfig() {
 	}
 
 	viper.SetDefault("SOURCES_API_PREFIX", "/api/sources/v3.1")
+	viper.SetDefault("ROS_ONPREM_DEPLOYMENT", false)
 	viper.SetDefault("SERVICE_NAME", "rosocp")
 	viper.SetDefault("API_PORT", "8000")
 	viper.SetDefault("KRUIZE_WAIT_TIME", "30")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,7 +72,7 @@ type Config struct {
 	SourceApiPrefix  string `mapstructure:"SOURCES_API_PREFIX"`
 
 	// On-prem deployment config
-	RosOnPremDeployment bool `mapstructure:"ROS_ONPREM_DEPLOYMENT"`
+	ONPREM bool `mapstructure:"ONPREM"`
 }
 
 var cfg *Config = nil
@@ -169,7 +169,7 @@ func initConfig() {
 	}
 
 	viper.SetDefault("SOURCES_API_PREFIX", "/api/sources/v3.1")
-	viper.SetDefault("ROS_ONPREM_DEPLOYMENT", false)
+	viper.SetDefault("ONPREM", false)
 	viper.SetDefault("SERVICE_NAME", "rosocp")
 	viper.SetDefault("API_PORT", "8000")
 	viper.SetDefault("KRUIZE_WAIT_TIME", "30")

--- a/internal/services/housekeeper/sourcesCleaner.go
+++ b/internal/services/housekeeper/sourcesCleaner.go
@@ -24,7 +24,7 @@ func StartSourcesListenerService() {
 	cfg := config.GetConfig()
 	var err error
 
-	if os.Getenv("ROS_ONPREM_DEPLOYMENT") == "true" {
+	if cfg.RosOnPremDeployment {
 		cost_app_id = 0
 		log.Infof("ROS_ONPREM_DEPLOYMENT flag is set, cost_app_id set to 0")
 	} else {

--- a/internal/services/housekeeper/sourcesCleaner.go
+++ b/internal/services/housekeeper/sourcesCleaner.go
@@ -24,9 +24,9 @@ func StartSourcesListenerService() {
 	cfg := config.GetConfig()
 	var err error
 
-	if os.Getenv("ON_PREM") == "true" {
+	if os.Getenv("ROS_ONPREM_DEPLOYMENT") == "true" {
 		cost_app_id = 0
-		log.Infof("ON_PREM flag is set, cost_app_id set to 0")
+		log.Infof("ROS_ONPREM_DEPLOYMENT flag is set, cost_app_id set to 0")
 	} else {
 		cost_app_id, err = sources.GetCostApplicationID()
 		if err != nil {

--- a/internal/services/housekeeper/sourcesCleaner.go
+++ b/internal/services/housekeeper/sourcesCleaner.go
@@ -24,9 +24,9 @@ func StartSourcesListenerService() {
 	cfg := config.GetConfig()
 	var err error
 
-	if cfg.RosOnPremDeployment {
+	if cfg.ONPREM {
 		cost_app_id = 0
-		log.Infof("ROS_ONPREM_DEPLOYMENT flag is set, cost_app_id set to 0")
+		log.Infof("ONPREM flag is set, cost_app_id set to 0")
 	} else {
 		cost_app_id, err = sources.GetCostApplicationID()
 		if err != nil {

--- a/internal/services/housekeeper/sourcesCleaner.go
+++ b/internal/services/housekeeper/sourcesCleaner.go
@@ -17,6 +17,9 @@ import (
 	"github.com/redhatinsights/ros-ocp-backend/internal/utils/sources"
 )
 
+// OnPremCostAppID is the default application ID used in on-prem deployments
+const OnPremCostAppID = 0
+
 var cost_app_id int
 
 func StartSourcesListenerService() {
@@ -25,8 +28,8 @@ func StartSourcesListenerService() {
 	var err error
 
 	if cfg.ONPREM {
-		cost_app_id = 0
-		log.Infof("ONPREM flag is set, cost_app_id set to 0")
+		cost_app_id = OnPremCostAppID
+		log.Infof("ONPREM flag is set, cost_app_id set to %d", OnPremCostAppID)
 	} else {
 		cost_app_id, err = sources.GetCostApplicationID()
 		if err != nil {

--- a/internal/services/housekeeper/sourcesCleaner.go
+++ b/internal/services/housekeeper/sourcesCleaner.go
@@ -23,10 +23,16 @@ func StartSourcesListenerService() {
 	log := logging.GetLogger()
 	cfg := config.GetConfig()
 	var err error
-	cost_app_id, err = sources.GetCostApplicationID()
-	if err != nil {
-		log.Error("Unable to get cost application id", err)
-		os.Exit(1)
+
+	if os.Getenv("ON_PREM") == "true" {
+		cost_app_id = 0
+		log.Infof("ON_PREM flag is set, cost_app_id set to 0")
+	} else {
+		cost_app_id, err = sources.GetCostApplicationID()
+		if err != nil {
+			log.Error("Unable to get cost application id", err)
+			os.Exit(1)
+		}
 	}
 
 	kafka.StartConsumer(cfg.SourcesEventTopic, sourcesListener)


### PR DESCRIPTION
## Overview

This PR removes the dependency on `sources-api-go` for on-prem deployments by eliminating the application type lookup and configuring the housekeeper to work directly with Koku's Kafka events.

## Motivation

As part of the migration to make Koku the single source of truth for sources:

- `ros-ocp-backend` previously made a REST call to `sources-api-go` at startup to get the cost-management application type ID
- This is no longer necessary since Koku now publishes source deletion events directly
- Simplifies the on-prem architecture by removing inter-service dependencies

## Changes

### Modified Files

| File | Changes |
|------|---------|
| `internal/config/config.go` | Added `ONPREM` configuration flag |
| `internal/services/housekeeper/sourcesCleaner.go` | Modified to skip application type filtering when ONPREM is enabled |

### Key Changes

#### 1. New ONPREM Configuration Flag

Added `ONPREM` environment variable to the config:

```go
// config.go
ONPREM bool
```

#### 2. Simplified Sources Cleaner

When `ONPREM=true`:
- Skips the REST call to `sources-api-go` to fetch application type ID
- Uses a constant application type ID (`0`) for cost-management
- Still filters Kafka events by `Application_type_id == 0`

### Application Type ID

For on-prem deployments, the application type ID is hardcoded to `0` (constant `OnPremCostAppID`). This is consistent with Koku, which publishes Kafka events with `Application_type_id: 0`. The housekeeper still filters events by application type ID, but uses the hardcoded value `0` instead of fetching it from sources-api-go.

Before (cloud mode):
```
1. On startup: GET /api/sources/v1.0/application_types?filter[name][eq]=/insights/platform/cost-management
2. Store application_type_id from response
3. On Kafka event: Filter by application_type_id
```

After (on-prem mode):
```
1. On startup: Set cost_app_id = 0 (constant)
2. On Kafka event: Filter by Application_type_id == 0
```

## Configuration

Set the following environment variable to enable on-prem mode:

```bash
ONPREM=true
```

## Testing

- Verified housekeeper correctly processes Kafka events from Koku
- Tested cluster cleanup when sources are deleted
- Confirmed no REST calls to sources-api-go when ONPREM is enabled

## Related PRs

- **koku**: Enables Sources API and publishes Kafka events on source deletion
- **cost-helm-chart**: Helm chart updates to configure ONPREM flag for ros-ocp-backend
